### PR TITLE
Use BASE_PATH, API_URL in `.env.production` instead of `cicd.yml`

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -32,8 +32,6 @@ jobs:
       - name: Load FIREBASE Config
         working-directory: front-end
         run: |
-            echo 'BASE_PATH=/practice-github-secrets' >> config/.env.production
-            echo 'API_URL=${{ secrets.FIREBASE_FUNCTIONS_API_URL }}' >> config/.env.production
             echo 'FIREBASE_API_KEY=${{ secrets.FIREBASE_API_KEY }}' >> config/.env.production
             echo 'FIREBASE_AUTH_DOMAIN=${{ secrets.FIREBASE_AUTH_DOMAIN }}' >> config/.env.production
             echo 'FIREBASE_PROJECT_ID=${{ secrets.FIREBASE_PROJECT_ID }}' >> config/.env.production


### PR DESCRIPTION
## 1. 어떤 목적으로 작업을 하셨나요
- Use BASE_PATH and API_URL in `.env.production` instead of `cicd.yml`

## 2. 위 목적을 달성하기 위해 어떤 작업을 하셨나요
- Remove BASE_PATH and API_URL in `cicd.yml`

## 3. 작업을 하면서 무엇을 느끼셨나요
- 데모버전에서 만들고 본 프로젝트로 옮길 때, 설정 값 같은거 주의하자!


